### PR TITLE
chore(config): simplify commitlint rules by removing overrides

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -3,14 +3,8 @@ module.exports = {
   rules: {
     'header-max-length': [2, 'always', 65],
     'body-max-line-length': [2, 'always', 72],
-    'scope-empty': [0],
-    'type-enum': [0],
     'signed-off-by': [2, 'always'],
     'body-leading-blank': [2, 'always'],
     'footer-leading-blank': [2, 'always'],
-    'subject-empty': [0],
-    'subject-full-stop': [0],
-    'type-empty': [0],
-    'type-case': [0],
   },
 };


### PR DESCRIPTION
This pull request makes the `commitlint.config.js` configuration stricter by removing exceptions that previously allowed empty or unconstrained commit message fields. This will enforce more consistent and descriptive commit messages.

Commit linting rule changes:

* Removed exceptions for empty `scope`, `type`, and `subject` fields, as well as for unconstrained `type` case and subject punctuation, making these fields now required and validated.Removed redundant rule overrides for type and scope checks in commitlint configuration. This makes the ruleset leaner and aligns with default conventional commit standards while keeping enforcement on header length, body formatting, and sign-off requirements.